### PR TITLE
Update site logos with scorecard design

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,12 +3,12 @@ permalink: pretty
 title: 'HAI Manifesto'
 
 logo:
-  mobile: "images/logo/hai-manifesto-mobile.svg"
-  mobile_height: "32px"
-  mobile_width: "32px"
-  desktop: "images/logo/hai-manifesto.svg"
-  desktop_height: "32px"
-  desktop_width: "240px"
+  mobile: "images/logo/hai-scorecard-mobile.svg"
+  mobile_height: "40px"
+  mobile_width: "40px"
+  desktop: "images/logo/hai-scorecard.svg"
+  desktop_height: "40px"
+  desktop_width: "40px"
 
 home: 
   limit_services: 6

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,10 @@
 <div class='header'>
   <div class="container">
     <div class="logo">
-      <a href="{{ site.baseurl }}"><img width="{{ site.logo.desktop_width }}" height="{{ site.logo.desktop_height }}" alt="{{ site.title }}" src="{{ site.logo.desktop | relative_url }}" /></a>
+      <a href="{{ site.baseurl }}"><img width="{{ site.logo.desktop_width }}" height="{{ site.logo.desktop_height }}" alt="{{ site.title }} logo" src="{{ site.logo.desktop | relative_url }}" /></a>
     </div>
     <div class="logo-mobile">
-      <a href="{{ site.baseurl }}"><img width="{{ site.logo.mobile_width }}" height="{{ site.logo.mobile_height }}" alt="{{ site.title }}" src="{{ site.logo.mobile | relative_url }}" /></a>
+      <a href="{{ site.baseurl }}"><img width="{{ site.logo.mobile_width }}" height="{{ site.logo.mobile_height }}" alt="{{ site.title }} logo" src="{{ site.logo.mobile | relative_url }}" /></a>
     </div>
     {% include main-menu.html %}
     {% include hamburger.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>{% if page.title %}{{page.title}}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon" type="image/png" href="{{ '/images/favicon.svg' | relative_url }}">
+  <link rel="icon" type="image/png" href="{{ '/images/favicon-new.svg' | relative_url }}">
   <!-- Google Fonts CDN -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/images/favicon-new.svg
+++ b/images/favicon-new.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 200 200" aria-label="favicon">
+  <defs>
+  <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-3-700)"/>
+
+  <g filter="url(#f-donut-3-700)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+</svg>

--- a/images/logo/hai-scorecard-mobile.svg
+++ b/images/logo/hai-scorecard-mobile.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 200 200" aria-label="HAI/">
+  <defs>
+  <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-3-700)"/>
+
+  <g filter="url(#f-donut-3-700)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+</svg>

--- a/images/logo/hai-scorecard.svg
+++ b/images/logo/hai-scorecard.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/">
+  <defs>
+  <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-3-700)"/>
+
+  <g filter="url(#f-donut-3-700)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+</svg>


### PR DESCRIPTION
## Summary
- create scorecard style logos for desktop and mobile
- update header to use new logos with alt text tweak
- add new favicon based on the scorecard donut
- update configuration for new logo dimensions
- reference new favicon in site layout

## Testing
- `bundle exec jekyll build` *(fails: bundler missing and install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887319be54083259dc3c8a9048cf4de