### PR TITLE
Update scorecard styles and manifesto layout

### DIFF
--- a/_layouts/manifesto.html
+++ b/_layouts/manifesto.html
@@ -18,17 +18,18 @@ bodyClass: "page-manifesto"
   <div class="row">
     {% assign cards = site.scorecards | sort: "weight" %}
     {% for card in cards %}
-    <div class="col-12 col-md-4 mb-3">
-      <div class="team team-summary">
+    <div class="col-12 col-md-6 mb-3">
+      <div class="team scorecard-summary">
         {% if card.image %}
-        <div class="team-image">
+        <div class="scorecard-image">
           <a href="{{ card.url | relative_url }}">
             <img width="60" height="60" alt="{{ card.title }}" class="img-fluid mb-2" src="{{ card.image | relative_url }}" />
           </a>
         </div>
         {% endif %}
-        <div class="team-meta">
-          <h2 class="team-name"><a href="{{ card.url | relative_url }}">{{ card.title }}</a></h2>
+        <div class="scorecard-meta">
+          {% assign score_name = card.title | split: " - " | first %}
+          <h2 class="team-name"><a href="{{ card.url | relative_url }}">{{ score_name }}</a></h2>
           {% if card.hi %}
           <p class="team-description small">HI: {{ card.hi }}%{% if card.hi_role %} - {{ card.hi_role }}{% endif %}</p>
           {% endif %}

--- a/_sass/pages/_page-manifesto.scss
+++ b/_sass/pages/_page-manifesto.scss
@@ -1,9 +1,9 @@
 .page-manifesto {
-  .team-summary {
+  .scorecard-summary {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    .team-image {
+    .scorecard-image {
       height: 60px;
       width: 60px;
       margin-right: 10px;
@@ -13,7 +13,7 @@
         width: 60px;
       }
     }
-    .team-meta {
+    .scorecard-meta {
       flex: 1;
       h2 {
         margin: 0;
@@ -28,7 +28,7 @@
         font-weight: 500;
       }
     }
-    .team-content {
+    .scorecard-content {
       margin-top: 20px;
       flex: 1 0 100%;
     }


### PR DESCRIPTION
## Summary
- rename CSS classes used for scorecards to `scorecard-*`
- adjust manifesto layout to show 2 scorecards per row
- show only the score name in scorecard titles

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878301bfc483258ceb64309f63eb85