### PR TITLE
Add scorecard section variables

### DIFF
--- a/_layouts/manifesto.html
+++ b/_layouts/manifesto.html
@@ -15,6 +15,19 @@ bodyClass: "page-manifesto"
 </div>
 
 <div class="container pt-6 pb-6">
+  {% if page.scorecards_title or page.scorecards_description %}
+  <div class="row">
+    <div class="col-12">
+      {% if page.scorecards_title %}
+      <h2>{{ page.scorecards_title }}</h2>
+      <hr>
+      {% endif %}
+      {% if page.scorecards_description %}
+      <p class="scorecards-description">{{ page.scorecards_description }}</p>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
   <div class="row">
     {% assign cards = site.scorecards | sort: "weight" %}
     {% for card in cards %}

--- a/index.md
+++ b/index.md
@@ -2,6 +2,8 @@
 title: The HAI/ Manifesto
 layout: manifesto
 description: The HAI/ Manifesto
+scorecards_title: "HAI/ Scale"
+scorecards_description: "These scorecards illustrate how human and AI contributions scale from HAI/0 to HAI/9."
 ---
 
 > *A New Creative Paradigm for Human / Artificial Intelligence*


### PR DESCRIPTION
## Summary
- allow manifesto layout to show section heading and description
- expose `scorecards_title` and `scorecards_description` in index front matter

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887974600d08325ae670d07bc24b12f