### PR TITLE
Align HAI/ Scale heading style

### DIFF
--- a/_layouts/manifesto.html
+++ b/_layouts/manifesto.html
@@ -8,26 +8,24 @@ bodyClass: "page-manifesto"
     <div class="col-12 col-md-8">
       <div class="service service-single">
         <h1 class="title">{{ page.title }}</h1>
-        <div class="content">{{ content }}</div>
+        <div class="content">
+          {{ content }}
+          {% if page.scorecards_title or page.scorecards_description %}
+            {% if page.scorecards_title %}
+            <h2>{{ page.scorecards_title }}</h2>
+            <hr>
+            {% endif %}
+            {% if page.scorecards_description %}
+            <p class="scorecards-description">{{ page.scorecards_description }}</p>
+            {% endif %}
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
 </div>
 
 <div class="container pt-6 pb-6">
-  {% if page.scorecards_title or page.scorecards_description %}
-  <div class="row">
-    <div class="col-12">
-      {% if page.scorecards_title %}
-      <h2>{{ page.scorecards_title }}</h2>
-      <hr>
-      {% endif %}
-      {% if page.scorecards_description %}
-      <p class="scorecards-description">{{ page.scorecards_description }}</p>
-      {% endif %}
-    </div>
-  </div>
-  {% endif %}
   <div class="row">
     {% assign cards = site.scorecards | sort: "weight" %}
     {% for card in cards %}


### PR DESCRIPTION
## Summary
- ensure the HAI/ Scale heading appears inside the `.content` container
- remove the old heading block

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879f8d4ebc8325ab5a7a98c67db141