### PR TITLE
Add languages menu

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -1,0 +1,6 @@
+- label: EN
+  url: "/"
+- label: PT
+  url: "/pt/"
+- label: FR
+  url: "/fr/"

--- a/_includes/languages-menu.html
+++ b/_includes/languages-menu.html
@@ -1,0 +1,9 @@
+{% if site.data.languages %}
+<nav id="languages-menu" class="languages-menu">
+  <ul>
+  {% for lang in site.data.languages %}
+    <li><a href="{{ lang.url | relative_url }}">{{ lang.label }}</a></li>
+  {% endfor %}
+  </ul>
+</nav>
+{% endif %}

--- a/_layouts/manifesto.html
+++ b/_layouts/manifesto.html
@@ -7,9 +7,10 @@ bodyClass: "page-manifesto"
   <div class="row justify-content-start">
     <div class="col-12 col-md-8">
 
-      <div class="service service-single">
-        <h1 class="title">{{ page.title }}</h1>
-        <div class="content">
+        <div class="service service-single">
+          <h1 class="title">{{ page.title }}</h1>
+          {% include languages-menu.html %}
+          <div class="content">
           {{ content }}
           {% if page.scorecards_title or page.scorecards_description %}
             {% if page.scorecards_title %}

--- a/_sass/components/_languages-menu.scss
+++ b/_sass/components/_languages-menu.scss
@@ -1,0 +1,20 @@
+.languages-menu {
+  margin-bottom: 20px;
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    li {
+      margin-right: 10px;
+      a {
+        color: $primary;
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -102,6 +102,7 @@ $sub-footer-text-color: $white;
 @import "components/main-menu";
 @import "components/main-menu-mobile";
 @import "components/hamburger";
+@import "components/languages-menu";
 @import "components/buttons";
 @import "components/call";
 @import "components/title";


### PR DESCRIPTION
## Summary
- add language data
- implement languages menu include
- show languages menu on the manifesto page
- style the new menu

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e06646d88325b3e8be772af5fb1b