### PR TITLE
Add Get Involved call-to-action link

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -2,6 +2,10 @@ main:
   - name: "Manifesto"
     url: "/"
     weight: 1
+  - name: "Get Involved"
+    url: "/get-involved/"
+    weight: 99
+    class: cta
 
 footer:
   - name: "Manifesto"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,6 +7,9 @@
       <a href="{{ '/' | relative_url }}"><img width="{{ site.logo.mobile_width }}" height="{{ site.logo.mobile_height }}" alt="{{ site.title }} logo" src="{{ site.logo.mobile | relative_url }}" /></a>
     </div>
     {% include main-menu.html %}
+    <div class="cta-mobile">
+      <a href="{{ '/get-involved/' | relative_url }}">Get Involved</a>
+    </div>
     {% include hamburger.html %}
   </div>
 </div>

--- a/_includes/main-menu-mobile.html
+++ b/_includes/main-menu-mobile.html
@@ -2,7 +2,7 @@
   {% assign mainmenu = site.data.menus.main | sort: 'weight'  %}
   <ul>
     {% for item in mainmenu %}
-    <li class="{% if item.url == page.url %}active{% endif %}">
+    <li class="{% if item.url == page.url %}active{% endif %}{% if item.class %} {{ item.class }}{% endif %}">
       <a href="{{ item.url | relative_url }}">{{ item.name }}</a>
     </li>
     {% endfor %}

--- a/_includes/main-menu.html
+++ b/_includes/main-menu.html
@@ -2,7 +2,7 @@
   {% assign mainmenu = site.data.menus.main | sort: 'weight'  %}
   <ul>
     {% for item in mainmenu %}
-    <li class="{% if item.url == page.url %}active{% endif %}">
+    <li class="{% if item.url == page.url %}active{% endif %}{% if item.class %} {{ item.class }}{% endif %}">
       <a href="{{ item.url | relative_url }}">{{ item.name }}</a>
     </li>
     {% endfor %}

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -12,6 +12,18 @@
     justify-content: space-between;
     align-items: center;
   }
+  .cta-mobile {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: bold;
+    a {
+      color: $secondary;
+      text-decoration: none;
+    }
+    @include media-breakpoint-up(sm) {
+      display: none;
+    }
+  }
   &.header-absolute {
     position: absolute;
     z-index: 10;

--- a/_sass/components/_main-menu-mobile.scss
+++ b/_sass/components/_main-menu-mobile.scss
@@ -61,6 +61,12 @@
           opacity: 0.8;
         }
       }
+      &.cta {
+        a {
+          font-weight: bold;
+          color: $secondary;
+        }
+      }
     }
   }
 }

--- a/_sass/components/_main-menu.scss
+++ b/_sass/components/_main-menu.scss
@@ -30,6 +30,12 @@
           }
         }
       }
+      &.cta {
+        > a {
+          font-weight: bold;
+          color: $secondary;
+        }
+      }
     }
   }
 }

--- a/get-involved.md
+++ b/get-involved.md
@@ -1,0 +1,9 @@
+---
+title: Get Involved
+layout: page
+description: Get Involved
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum. Cras venenatis euismod malesuada. Nulla facilisi.
+
+Mauris non tempor quam, et lacinia sapien. Mauris accumsan eros eget libero posuere vulputate. Etiam ultricies nisi vel augue.


### PR DESCRIPTION
## Summary
- add "Get Involved" content page
- append bold orange "Get Involved" link to navigation and mobile header

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688dc36785188325b5cacdc187685910