### PR TITLE
Style Get Involved button and add footer link

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -11,3 +11,6 @@ footer:
   - name: "Manifesto"
     url: "/"
     weight: 1
+  - name: "Get Involved"
+    url: "/get-involved/"
+    weight: 99

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -15,10 +15,17 @@
   .cta-mobile {
     display: block;
     font-size: 0.8rem;
-    font-weight: bold;
+    font-weight: normal;
     a {
-      color: $secondary;
+      background: $secondary;
+      color: $primary;
+      border-radius: 4px;
+      padding: 6px 12px;
       text-decoration: none;
+      &:hover {
+        background-color: lighten($secondary, 10%);
+        text-decoration: none;
+      }
     }
     @include media-breakpoint-up(sm) {
       display: none;

--- a/_sass/components/_main-menu-mobile.scss
+++ b/_sass/components/_main-menu-mobile.scss
@@ -63,8 +63,16 @@
       }
       &.cta {
         a {
-          font-weight: bold;
-          color: $secondary;
+          font-weight: normal;
+          background: $secondary;
+          color: $primary;
+          border-radius: 4px;
+          padding: 6px 12px;
+          display: inline-block;
+          &:hover {
+            background-color: lighten($secondary, 10%);
+            opacity: 1;
+          }
         }
       }
     }

--- a/_sass/components/_main-menu.scss
+++ b/_sass/components/_main-menu.scss
@@ -32,8 +32,15 @@
       }
       &.cta {
         > a {
-          font-weight: bold;
-          color: $secondary;
+          font-weight: normal;
+          background: $secondary;
+          color: $primary;
+          border-radius: 4px;
+          padding: 6px 14px;
+          &:hover {
+            background-color: lighten($secondary, 10%);
+            text-decoration: none;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Style the Get Involved header link as an orange button with navy text
- Add Get Involved to footer menu

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688dc72f800c8325954d4771fba07cdc