### PR TITLE
Add Related Studies page and menu entry

### DIFF
--- a/Studies.md
+++ b/Studies.md
@@ -1,0 +1,43 @@
+---
+title: Related Studies
+layout: page
+description: Related Studies
+permalink: /studies/
+---
+
+### Studies supporting “AI contributions must be transparent”
+
+- **[Lessons learned: Transparency around using AI needs to be specific to maintain trust](https://hsph.harvard.edu/health-communication/news/lessons-learned-transparency-around-using-ai-needs-to-be-specific-to-maintain-trust/){:target="_blank"}** – [Source](https://hsph.harvard.edu/health-communication/news/lessons-learned-transparency-around-using-ai-needs-to-be-specific-to-maintain-trust/){:target="_blank"}  
+  Randomized experiment (N = 1,483) shows AI labels can **lower organisational trust** unless paired with precise source lists, highlighting nuance in disclosure.
+
+- **[Labeling Messages as AI-Generated Does Not Reduce Their Persuasive Effects](https://arxiv.org/abs/2504.09865){:target="_blank"}** – [PDF](https://arxiv.org/pdf/2504.09865){:target="_blank"}  
+  Survey experiment (N = 1,601) finds authorship labels boost transparency yet **don’t affect persuasion**.
+
+### Studies supporting “Collaboration is layered”
+
+- **[When humans and AI work best together — and when each is better alone](https://mitsloan.mit.edu/ideas-made-to-matter/when-humans-and-ai-work-best-together-and-when-each-better-alone){:target="_blank"}** – [Source](https://mitsloan.mit.edu/ideas-made-to-matter/when-humans-and-ai-work-best-together-and-when-each-better-alone){:target="_blank"}  
+  Review of 106 experiments shows combinations excel when roles complement but underperform in algorithm-dominant tasks, underscoring **role-layer matching**.
+
+- **[When combinations of humans and AI are useful: A systematic review and meta-analysis](https://www.nature.com/articles/s41562-024-02024-1){:target="_blank"}** – [Source](https://www.nature.com/articles/s41562-024-02024-1){:target="_blank"}  
+  Meta-analysis of 370 effect sizes finds **content-creation tasks gain most** from human-AI synergy, while decision tasks often suffer.
+
+- **[Examining human–AI collaboration in hybrid intelligence learning environments](https://www.nature.com/articles/s41599-025-05097-z){:target="_blank"}** – [Source](https://www.nature.com/articles/s41599-025-05097-z){:target="_blank"}  
+  Classroom case study proposes a *Synergy Degree Model*; synergy fluctuates **low-to-moderate** and maps clear teacher/AI layers.
+
+- **[Human-AI Co-Creativity: Exploring Synergies Across Levels of Creative Collaboration](https://arxiv.org/abs/2411.12527){:target="_blank"}** – [PDF](https://arxiv.org/pdf/2411.12527){:target="_blank"}  
+  Framework details four collaboration levels (Digital Pen → AI Co-Creator) with empirical cases showing creative gains when **responsibilities are explicitly layered**.
+
+- **[Human-generative AI collaboration enhances task performance but undermines human’s intrinsic motivation](https://www.nature.com/articles/s41598-025-98385-2){:target="_blank"}** – [Source](https://www.nature.com/articles/s41598-025-98385-2){:target="_blank"}  
+  Series of four studies (N = 3,562) finds immediate performance boosts yet **drops in long-term motivation**, stressing careful layering for sustainable teamwork.
+
+### Studies supporting “Responsibility stays with people”
+
+- **[Influence of AI behavior on human moral decisions, agency, and responsibility](https://www.nature.com/articles/s41598-025-95587-6){:target="_blank"}** – [Source](https://www.nature.com/articles/s41598-025-95587-6){:target="_blank"}  
+  Drone-operator experiment shows AI advice shifts moral choices and **reduces explicit responsibility**, evidencing real “responsibility gaps.”
+
+- **[AI Explainability: How to Avoid Rubber-Stamping Recommendations](https://sloanreview.mit.edu/article/ai-explainability-how-to-avoid-rubber-stamping-recommendations/){:target="_blank"}** – [Source](https://sloanreview.mit.edu/article/ai-explainability-how-to-avoid-rubber-stamping-recommendations/){:target="_blank"}  
+  Panel of experts and 1,221-respondent survey conclude **explainability & human oversight are complementary safeguards**; without explanations, oversight devolves to rubber-stamping.
+
+- **[Accountable Artificial Intelligence: Holding Algorithms to Account](https://pmc.ncbi.nlm.nih.gov/articles/PMC8518786/){:target="_blank"}** – [PDF](https://pmc.ncbi.nlm.nih.gov/articles/PMC8518786/pdf){:target="_blank"}  
+  Public-sector analysis urges **transparent, interpretable models** so humans can answer for algorithmic decisions (information-explanation-consequence triad).
+

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -2,6 +2,9 @@ main:
   - name: "Manifesto"
     url: "/"
     weight: 1
+  - name: "Studies"
+    url: "/studies/"
+    weight: 90
   - name: "Get Involved"
     url: "/get-involved/"
     weight: 99


### PR DESCRIPTION
## Summary
- add a new **Related Studies** page compiling research on transparency, collaboration layers, and human responsibility
- link the Studies page in the main menu with weight 90

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_688df42d6e488325b073205dc36608b3