### PR TITLE
Update branding to AI/M

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 baseurl: 'https://haimanifesto.org'
 permalink: pretty
-title: 'HAI/ Manifesto'
+title: 'AI/M'
 
 logo:
   mobile: "images/logo/hai-scorecard-mobile.svg"

--- a/images/logo/hai-scorecard-mobile.svg
+++ b/images/logo/hai-scorecard-mobile.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 200 200" aria-label="HAI/">
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 200 200" aria-label="AI/M">
   <defs>
   <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
     <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
@@ -32,5 +32,5 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/M</text>
 </svg>

--- a/images/logo/hai-scorecard.svg
+++ b/images/logo/hai-scorecard.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/">
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="AI/M">
   <defs>
   <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
     <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
@@ -32,5 +32,5 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/M</text>
 </svg>


### PR DESCRIPTION
## Summary
- use "AI/M" as site title for footer branding
- replace "HAI/" with "AI/M" in desktop and mobile logo SVGs

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: jekyll command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f22506f808325a8bc85dc44865a06