### PR TITLE
Use Authorship-Indicator term and refine scorecard labels

### DIFF
--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S0.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S0.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">0</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S1.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S1.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">1</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S2.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S2.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">2</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S3.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S3.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">3</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S4.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S4.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">4</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S5.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S5.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">5</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S6.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S6.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">6</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S7.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S7.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">7</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S8.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S8.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">8</text>
 </svg>

--- a/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S9.svg
+++ b/assets/scorecards/print-solid-dark/AIM_sticker_print_darkSolid_S9.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#FFFFFF">9</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S0.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S0.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">0</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S1.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S1.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">1</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S2.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S2.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">2</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S3.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S3.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">3</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S4.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S4.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">4</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S5.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S5.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">5</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S6.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S6.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">6</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S7.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S7.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">7</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S8.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S8.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">8</text>
 </svg>

--- a/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S9.svg
+++ b/assets/scorecards/print-solid-light/AIM_sticker_print_lightSolid_S9.svg
@@ -17,8 +17,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">9</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S0.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S0.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">0</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S1.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S1.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">1</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S2.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S2.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">2</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S3.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S3.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">3</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S4.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S4.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">4</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S5.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S5.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">5</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S6.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S6.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">6</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S7.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S7.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">7</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S8.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S8.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">8</text>
 </svg>

--- a/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S9.svg
+++ b/assets/scorecards/translucent-dark/AIM_sticker_darkPlate10_S9.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">9</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S0.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S0.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">0</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S1.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S1.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">1</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S2.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S2.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">2</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S3.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S3.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">3</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S4.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S4.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">4</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S5.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S5.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">5</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S6.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S6.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">6</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S7.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S7.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">7</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S8.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S8.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">8</text>
 </svg>

--- a/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S9.svg
+++ b/assets/scorecards/translucent-light/AIM_sticker_lightPlate14_S9.svg
@@ -32,8 +32,8 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
+  <text x="100" y="80" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/</text>
   <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
         font-size="37" font-weight="700" fill="#0B2545">9</text>
 </svg>

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
-title: The Authorship Indicator Manifesto
+title: The Authorship-Indicator Manifesto
 layout: manifesto
-description: The Authorship Indicator Manifesto
+description: The Authorship-Indicator Manifesto
 scorecards_description: You are invited to use the AI/M Scorecards for your own creation
 ---
 


### PR DESCRIPTION
## Summary
- replace 'Authorship Indicator' with 'Authorship-Indicator' on the manifesto index page
- regenerate scorecard SVGs with slightly larger, higher-positioned `AI/` labels for balanced spacing

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_688f36be018883259b8ec60c109b2eaf