### PR TITLE
Rename AI/M references to AI:M

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 baseurl: 'https://haimanifesto.org'
 permalink: pretty
-title: 'AI/M'
+title: 'AI:M'
 
 logo:
   mobile: "images/logo/aim-scorecard-mobile.svg"

--- a/images/logo/aim-scorecard-mobile.svg
+++ b/images/logo/aim-scorecard-mobile.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 200 200" aria-label="AI/M">
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 200 200" aria-label="AI:M">
   <defs>
   <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
     <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
@@ -32,5 +32,5 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/M</text>
+<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI:M</text>
 </svg>

--- a/images/logo/aim-scorecard.svg
+++ b/images/logo/aim-scorecard.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="AI/M">
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="AI:M">
   <defs>
   <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
     <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
@@ -32,5 +32,5 @@
 
   <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
 
-<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI/M</text>
+<text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="37" font-weight="700" letter-spacing="0.5" fill="#0B2545">AI:M</text>
 </svg>

--- a/index.md
+++ b/index.md
@@ -1,8 +1,8 @@
 ---
-title: The Authorship-Indicator Manifesto
+title: Authorship Indicators: A Manifesto
 layout: manifesto
-description: The Authorship-Indicator Manifesto
-scorecards_description: You are invited to use the AI/M Scorecards for your own creation
+description: Authorship Indicators: A Manifesto
+scorecards_description: You are invited to use the AI:M Scorecards for your own creation
 ---
 
 > *A New Creative Paradigm for Human / Artificial Intelligence*
@@ -10,11 +10,11 @@ scorecards_description: You are invited to use the AI/M Scorecards for your own 
 **Authorship is evolving.** Most creators — novelists, designers, coders, composers — already weave generative AI into their process, sketching storyboards, remixing beats, or colour-grading photos at machine speed. 
 This Manifesto looks ahead to a near future in which AI will be present in almost every form of creative work — often invisibly. In that context, clearly identifying how a work was made will no longer be optional, but essential. Transparency about the “ingredients” of creation will be necessary for the healthy preservation of trust, meaning, and responsibility in a world of hybrid authorship.
 
-> The HAI/ Manifesto proposes a structured way to describe and disclose the role of artificial intelligence in creative work — openly, accurately, and in context.
+> The Authorship Indicators Manifesto proposes a structured way to describe and disclose the role of artificial intelligence in creative work — openly, accurately, and in context.
 
 It is not the role of this manifesto to create systems of reward or coercion. It does not aim to incentivize disclosure through benefits, nor to enforce it through constraints. The HAI/ Manifesto is a call, the HAI/ Framework a set of principles, and the HAI/ Score a tool for orientation and transparency.
 
-## AI/M Framework
+## AI:M Framework
 
 The framework is a practical method for describing how artificial intelligence contributes to the creation of a work — making visible the degree and nature of human–machine collaboration.
 
@@ -24,7 +24,7 @@ It encourages **creators** to clearly state how AI tools were used, and invites 
 
 It may be argued that creators will, in practice, avoid disclosing their use of AI — whether out of habit, uncertainty, or strategic silence. But the need for transparency does not rely on perfect honesty. It reflects a structural shift in authorship that must be addressed. Even if disclosure is uneven at first, the existence of a shared framework — and the cultural expectation it establishes — is essential. Acknowledging machine contributions is not only a question of compliance, but of creative integrity.
 
-## AI/M Principles
+## AI:M Principles
 
 This framework is based on the acknowledgment that machines may contribute, but the human remains the source of intention, judgment, and responsibility — a foundation that gives rise to the following key principles:
 
@@ -33,7 +33,7 @@ This framework is based on the acknowledgment that machines may contribute, but 
 3. **Responsibility stays with people.** Decisions, interpretations, and impacts are human matters.
 
 
-## AI/M Score
+## AI:M Score
 
 The HAI/ Score is a **classification system**, supported by scorecards, that signals the degree and nature of AI involvement in the creation of any work — novel, film sequence, orchestral score, source code — ranking it from fully human-made to fully machine-generated with distinct levels reflecting the balance of authorship.
 
@@ -41,6 +41,6 @@ The HAI/ Score is a **classification system**, supported by scorecards, that sig
 
 Some situations — such as personal expression or educational evaluation — may call for minimal AI involvement. Others — such as technical, scientific, or analytical work — may benefit from more substantial support, especially when accuracy, consistency, or scale are priorities.
 
-## AI/M Scale
+## AI:M Scale
 
 The scorecards illustrate how human and AI contributions scale from HAI/0 to HAI/9 — providing creators with a reference for self-assessing their process, and offering publishers, institutions, or platforms a consistent way to understand and communicate the level of collaboration behind a work.


### PR DESCRIPTION
## Summary
- rename manifest title and description to "Authorship Indicators: A Manifesto"
- update manifesto copy and section headings to use AI:M terminology
- update site configuration and logo SVGs for new AI:M naming

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_688f39030aa08325a91784ff65e6d11a