### PR TITLE
Sync translation index scale references

### DIFF
--- a/de/index.md
+++ b/de/index.md
@@ -41,4 +41,4 @@ Manche Situationen — etwa persönliche Ausdrucksformen oder bildungsbezogene B
 
 ## AI:M Skala
 
-Die Scorecards veranschaulichen, wie sich menschliche und KI‑Beiträge von AI:M0 bis AI:M9 staffeln — und liefern Kreativen eine Orientierung zur Selbsteinschätzung ihres Prozesses sowie Verlagen, Institutionen oder Plattformen eine einheitliche Möglichkeit, das Maß der Zusammenarbeit hinter einem Werk zu verstehen und zu kommunizieren.
+Die Scorecards veranschaulichen, wie sich menschliche und KI‑Beiträge von AI:0 bis AI:9 staffeln — und liefern Kreativen eine Orientierung zur Selbsteinschätzung ihres Prozesses sowie Verlagen, Institutionen oder Plattformen eine einheitliche Möglichkeit, das Maß der Zusammenarbeit hinter einem Werk zu verstehen und zu kommunizieren.

--- a/es/index.md
+++ b/es/index.md
@@ -41,4 +41,4 @@ Algunas situaciones — como la expresión personal o la evaluación educativa �
 
 ## Escala AI:M
 
-Las **fichas** de puntuación ilustran cómo escalan las contribuciones humanas y de la IA desde AI:M0 hasta AI:M9 — proporcionando a los creadores una referencia para autoevaluar su proceso y ofreciendo a editores, instituciones o plataformas una forma coherente de comprender y comunicar el nivel de colaboración detrás de una obra.
+Las **fichas** de puntuación ilustran cómo escalan las contribuciones humanas y de la IA desde AI:0 hasta AI:9 — proporcionando a los creadores una referencia para autoevaluar su proceso y ofreciendo a editores, instituciones o plataformas una forma coherente de comprender y comunicar el nivel de colaboración detrás de una obra.

--- a/fr/index.md
+++ b/fr/index.md
@@ -41,4 +41,4 @@ Certaines situations — comme l'expression personnelle ou l'évaluation pédago
 
 ## AI:M Échelle
 
-Les fiches illustrent comment les contributions humaines et celles de l'IA se déploient du AI:M0 au AI:M9 — offrant aux créateurs un repère pour s’autoévaluer et proposant aux éditeurs, institutions ou plateformes un moyen cohérent de comprendre et de communiquer le niveau de collaboration derrière une œuvre.
+Les fiches illustrent comment les contributions humaines et celles de l'IA se déploient du AI:0 au AI:9 — offrant aux créateurs un repère pour s’autoévaluer et proposant aux éditeurs, institutions ou plateformes un moyen cohérent de comprendre et de communiquer le niveau de collaboration derrière une œuvre.

--- a/it/index.md
+++ b/it/index.md
@@ -41,4 +41,4 @@ Alcune situazioni — come l’espressione personale o la valutazione didattica 
 
 ## Scala AI:M
 
-Le schede mostrano come i contributi umani e dell’IA si sviluppano da AI:M0 a AI:M9 — fornendo ai creatori un riferimento per autovalutare il proprio processo e offrendo a editori, istituzioni o piattaforme un modo coerente di comprendere e comunicare il livello di collaborazione dietro a un’opera.
+Le schede mostrano come i contributi umani e dell’IA si sviluppano da AI:0 a AI:9 — fornendo ai creatori un riferimento per autovalutare il proprio processo e offrendo a editori, istituzioni o piattaforme un modo coerente di comprendere e comunicare il livello di collaborazione dietro a un’opera.


### PR DESCRIPTION
## Summary
- Remove the extra 'M' from AI scale references in Spanish, French, German, and Italian index pages to match the English version.

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688f4102aedc8325ac5d6d460cfb6633