### PR TITLE
chore: refine manifesto translations

### DIFF
--- a/de/index.md
+++ b/de/index.md
@@ -9,7 +9,7 @@ description: "Indikatoren der Urheberschaft: Ein Manifest"
 **Urheberschaft entwickelt sich weiter.** Die meisten Kreativen — Romanautoren, Designer, Programmierer, Komponisten — integrieren bereits generative KI in ihren Arbeitsprozess, skizzieren Storyboards, remixen Beats oder kolorieren Fotos mit maschineller Geschwindigkeit. 
 Dieses Manifest blickt in eine nahe Zukunft, in der KI in nahezu jeder Form kreativer Arbeit präsent sein wird — oft unsichtbar. In diesem Kontext wird es unerlässlich sein, klar zu kennzeichnen, wie ein Werk entstanden ist. Transparenz über die «Zutaten» der Erstellung wird notwendig sein, um Vertrauen, Sinn und Verantwortung in einer Welt hybrider Autorenschaft zu bewahren.
 
-> Das AI:M Manifest bietet eine strukturierte Möglichkeit, die Rolle von künstlicher Intelligenz in kreativer Arbeit zu beschreiben und offenzulegen — offen, präzise und im Kontext.
+> Das Manifest der Indikatoren der Urheberschaft bietet eine strukturierte Möglichkeit, die Rolle von künstlicher Intelligenz in kreativer Arbeit zu beschreiben und offenzulegen — offen, präzise und im Kontext.
 
 Es ist nicht Aufgabe dieses Manifests, Systeme der Belohnung oder Zwang zu schaffen. Es hat nicht das Ziel, Offenlegung durch Vorteile zu fördern oder sie durch Einschränkungen durchzusetzen. Das AI:M Manifest ist ein Aufruf, das AI:M Rahmenwerk ein Satz von Prinzipien, und der AI:M Score ein Werkzeug zur Orientierung und Transparenz.
 

--- a/es/index.md
+++ b/es/index.md
@@ -9,7 +9,7 @@ description: "Indicadores de Autoría: Un Manifiesto"
 **La autoría está evolucionando.** La mayoría de los creadores — novelistas, diseñadores, programadores, compositores — ya integran la IA generativa en su proceso, esbozando guiones gráficos, remezclando ritmos o ajustando el color de las fotos a velocidad de máquina. 
 Este Manifiesto mira hacia un futuro cercano en el que la IA estará presente en casi todas las formas de trabajo creativo — a menudo de forma invisible. En ese contexto, identificar claramente cómo se hizo una obra dejará de ser opcional para convertirse en algo esencial. La transparencia sobre los “ingredientes” de la creación será necesaria para preservar de forma sana la confianza, el sentido y la responsabilidad en un mundo de autoría híbrida.
 
-> El Manifiesto AI:M propone una forma estructurada de describir y revelar el papel de la inteligencia artificial en la creación — de manera abierta, precisa y contextual.
+> El Manifiesto de Indicadores de Autoría propone una forma estructurada de describir y revelar el papel de la inteligencia artificial en la creación — de manera abierta, precisa y contextual.
 
 No es función de este manifiesto crear sistemas de recompensa o coacción. No pretende incentivar la divulgación mediante beneficios ni imponerla a través de restricciones. El Manifiesto AI:M es un llamamiento, el Marco AI:M un conjunto de principios y la Puntuación AI:M una herramienta de orientación y transparencia.
 

--- a/fr/index.md
+++ b/fr/index.md
@@ -9,7 +9,7 @@ description: "Indicateurs d'autorat : un manifeste"
 **La notion d'auteur évolue.** La plupart des créateurs — romanciers, designers, développeurs, compositeurs — intègrent déjà l'IA générative dans leur processus, esquissant des storyboards, remixant des rythmes ou corrigeant des couleurs à la vitesse de la machine. 
 Ce Manifeste regarde vers un futur proche où l'IA sera présente dans presque toutes les formes de création — souvent de manière invisible. Dans ce contexte, identifier clairement comment une œuvre a été réalisée ne sera plus facultatif, mais essentiel. La transparence sur les « ingrédients » de la création sera nécessaire pour préserver sainement la confiance, le sens et la responsabilité dans un monde d'autorat hybride.
 
-> Le Manifeste AI:M propose une méthode structurée pour décrire et divulguer le rôle de l'intelligence artificielle dans la création — ouvertement, précisément et dans son contexte.
+> Le Manifeste des Indicateurs d'Autorat propose une méthode structurée pour décrire et divulguer le rôle de l'intelligence artificielle dans la création — ouvertement, précisément et dans son contexte.
 
 Il ne revient pas à ce manifeste de mettre en place des systèmes de récompense ou de coercition. Il n’a pas pour but d’encourager la divulgation par des avantages ni de l’imposer par des contraintes. Le Manifeste AI:M est un appel, le Cadre AI:M un ensemble de principes, et le Score AI:M un outil d’orientation et de transparence.
 

--- a/it/index.md
+++ b/it/index.md
@@ -9,7 +9,7 @@ description: "Indicatori di Autorialità: Un Manifesto"
 **Il concetto di autorialità si sta evolvendo.** La maggior parte dei creatori — romanzieri, designer, programmatori, compositori — integra già l’IA generativa nel proprio processo, abbozzando storyboard, remixando beat o correggendo i colori delle foto a velocità di macchina. 
 Questo Manifesto guarda a un futuro prossimo in cui l’IA sarà presente in quasi ogni forma di lavoro creativo — spesso in modo invisibile. In tale contesto, identificare chiaramente come è stata realizzata un’opera non sarà più facoltativo, ma essenziale. La trasparenza sugli “ingredienti” della creazione sarà necessaria per preservare in modo sano la fiducia, il significato e la responsabilità in un mondo di autorialità ibrida.
 
-> Il Manifesto AI:M propone un modo strutturato di descrivere e divulgare il ruolo dell’intelligenza artificiale nelle opere creative — apertamente, con precisione e nel contesto.
+> Il Manifesto degli Indicatori di Autorialità propone un modo strutturato di descrivere e divulgare il ruolo dell’intelligenza artificiale nelle opere creative — apertamente, con precisione e nel contesto.
 
 Non è compito di questo manifesto creare sistemi di ricompensa o coercizione. Non mira a incentivare la divulgazione tramite vantaggi né a imporla attraverso vincoli. Il Manifesto AI:M è un appello, il Quadro AI:M un insieme di principi e il Punteggio AI:M uno strumento di orientamento e trasparenza.
 


### PR DESCRIPTION
## Summary
- refine translation of "The Authorship Indicators Manifesto proposes a structured way to describe" in Spanish, French, German and Italian index pages

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688f43da1e3883259eb21071f59c8c5e